### PR TITLE
Reset working tree when conflict by merge

### DIFF
--- a/commands/topic-deploy.go
+++ b/commands/topic-deploy.go
@@ -33,6 +33,7 @@ func TopicDeploy(args []string, conf config.ConfData) (string, error) {
 
 func (td *TopicDeployOpts) Exec() (string, error) {
 	git := &git.Git{WorkDir: td.Config.GitWorkDir}
+	defer git.Reset("HEAD", true)
 
 	owner, repo, err := git.FetchOwnerAndRepo()
 	if err != nil {

--- a/git/git.go
+++ b/git/git.go
@@ -126,6 +126,22 @@ func (g *Git) FetchOwnerAndRepo() (string, string, error) {
 	return matches[1], matches[2], nil
 }
 
+func (g *Git) Reset(branchName string, isReset bool) error {
+
+	args := []string{"reset", branchName}
+	if isReset {
+		args = append(args, "--reset")
+	}
+
+	c := cmd.Cmd{
+		Name: "git",
+		Args: g.appendGitOptions(args),
+	}
+
+	_, err := c.Exec()
+	return err
+}
+
 func (g *Git) appendGitOptions(args []string) []string {
 	gitOptions := []string{"--git-dir", g.WorkDir + "/.git", "--work-tree", g.WorkDir}
 	return append(gitOptions, args...)


### PR DESCRIPTION
topic-deploy時にコンフリクトしてマージに失敗した場合に、
working treeが汚れた状態のままになってしまい、次回のtopic-deploy移行も失敗するケースが有りました。
ですので、topic-deployをやった時に必ず`git reset HEAD --hard`を行うことでworking treeをきれいにしてマージできるようにしました。
