### PR TITLE
add setting file for travis.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+  - 1.4
+  - 1.5
+  - tip
+sudo: false


### PR DESCRIPTION
testing on travis.org is enabled (https://travis-ci.org/MacoTasu/gopher ), but tests are fail because there is no setting file.
