### PR TITLE
fmt.Errorf と fmt.Sprintf が重なってるのをやめて errors.New を使う

### DIFF
--- a/mirage/mirage.go
+++ b/mirage/mirage.go
@@ -1,9 +1,11 @@
 package mirage
 
 import (
+	"errors"
+	"fmt"
+
 	"../cmd"
 	"../util"
-	"fmt"
 )
 
 type Mirage struct {
@@ -20,7 +22,7 @@ func (m *Mirage) Launch() (string, error) {
 	}
 
 	if percentage <= 15 {
-		return "", fmt.Errorf(fmt.Sprintf("Can't launch. AvailableMemory: %d%%\n", percentage))
+		return "", errors.New(fmt.Sprintf("Can't launch. AvailableMemory: %d%%\n", percentage))
 	}
 
 	c := cmd.Cmd{


### PR DESCRIPTION
```
ʕ ◔ϖ◔ʔ < launch not ybsk
ʕ ◔ϖ◔ʔ < Can't launch. AvailableMemory: 14%!
(MISSING)
```

`fmt.Errorf`は % の後ろにフォーマット指定文字を期待しているけれど、それがないので `(MISSING)` になってしまう。
