### PR TITLE
send custom args of building by jenkins

### DIFF
--- a/commands/launch.go
+++ b/commands/launch.go
@@ -17,6 +17,7 @@ type LaunchOpts struct {
 	BranchName string
 	Config     config.ConfData
 	Launcher   string
+	ExtraArgs  []string
 }
 
 func Launch(args []string, conf config.ConfData, launcher string) (string, error) {
@@ -24,7 +25,16 @@ func Launch(args []string, conf config.ConfData, launcher string) (string, error
 		return "", fmt.Errorf("not enough argument")
 	}
 
-	l := &LaunchOpts{Subdomain: args[0], BranchName: args[1], Config: conf, Launcher: launcher}
+	l := &LaunchOpts{
+		Subdomain:  args[0],
+		BranchName: args[1],
+		Config:     conf,
+		Launcher:   launcher,
+	}
+	if len(args) >= 3 {
+		l.ExtraArgs = args[2:]
+	}
+
 	return l.Exec()
 }
 

--- a/commands/topic-launch.go
+++ b/commands/topic-launch.go
@@ -15,6 +15,7 @@ type TopicLaunchOpts struct {
 	IssueNumber int
 	Config      config.ConfData
 	Launcher    string
+	ExtraArgs   []string
 }
 
 func TopicLaunch(args []string, conf config.ConfData, launcher string) (string, error) {
@@ -27,7 +28,15 @@ func TopicLaunch(args []string, conf config.ConfData, launcher string) (string, 
 		return "", err
 	}
 
-	tl := &TopicLaunchOpts{Subdomain: args[0], IssueNumber: number, Config: conf, Launcher: launcher}
+	tl := &TopicLaunchOpts{
+		Subdomain:   args[0],
+		IssueNumber: number,
+		Config:      conf,
+		Launcher:    launcher,
+	}
+	if len(args) > 2 {
+		tl.ExtraArgs = args[2:]
+	}
 	return tl.Exec()
 }
 
@@ -77,7 +86,13 @@ func (tl *TopicLaunchOpts) Exec() (string, error) {
 
 	git.PushRemote(deployRefName)
 
-	lo := &LaunchOpts{Subdomain: tl.Subdomain, BranchName: deployRefName, Config: tl.Config, Launcher: tl.Launcher}
+	lo := &LaunchOpts{
+		Subdomain:  tl.Subdomain,
+		BranchName: deployRefName,
+		Config:     tl.Config,
+		Launcher:   tl.Launcher,
+		ExtraArgs:  tl.ExtraArgs,
+	}
 
 	return lo.Exec()
 }


### PR DESCRIPTION
Jenkinsによるビルドを行う際にカスタムパラメータをテンプレで送れるようにしました
ビルド時にSlackからのコマンドにくっついているオプションを任意のキーのパラメータとして送れるように出来ます
